### PR TITLE
hands-on-1: add host port forward note

### DIFF
--- a/hands-on-1/README.md
+++ b/hands-on-1/README.md
@@ -22,7 +22,7 @@ chmod +x flatcar_production_qemu.sh
 ./flatcar_production_qemu.sh -- -display curses
 ```
 
-NOTE: start flatcar with a port forward to access the nginx service from your host
+NOTE: it's possible to start Flatcar with a port forwarding to access the Nginx server from your host
 ``` bash
 ./flatcar_production_qemu.sh -p 8080-:80,hostfwd=tcp::2222 -- -display curses
 ```


### PR DESCRIPTION
# hands-on-1: add host port forwarding

Add a note on how to pass a port forwarding parameter to the qemu script. This allows a user to reach the flatcar nginx service also from your host PC.


